### PR TITLE
Fix bug that stopped dances from starting under certain conditions

### DIFF
--- a/lua/entities/sent_dance_base.lua
+++ b/lua/entities/sent_dance_base.lua
@@ -1503,6 +1503,7 @@ if (CLIENT) then
 	end
 	
 	function ENT:OnCreatedAudioStream(audio,tag)
+		local ply = LocalPlayer()
 		if tag == "Preview" then
 			ply.VJ_Persona_DancePreview_Theme_Audio = audio
 		end


### PR DESCRIPTION
Feel free to ignore this, but this fixed my issue with the dances not working at all. It's been a very long time since I've done GMod addon work / Lua scripting, so I'm thinking this may be an issue with variable scope maybe? I'm assuming there's a reason the way it was originally.